### PR TITLE
bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ DEMO_PROVIDER_PK="<Put your Second Private Key in here>"
 
 This will allow the scripts that you will later run in this demo, to use your `Provider` and your `User` Wallets.
 
+In order to run the following scripts, you must first compile the smart contracts. Run:
+
+```
+npx buidler compile
+```
+
 # GELATO DEMO: AUTOMATED KYBER
 
 **Follow the Steps of this walkthrough demo, to learn how you can use Gelato to build your Dapp that enables Users to `automatically trade ETH for KNC on KyberNetwork every X minutes/days/weeks`... .**

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ cd gelato-kyber
 
 yarn install  # or npm install
 
-npx buidler compile
 ```
 
 You will probably see some `gyp-error` depending on which version of `node` you use. Don't worry about it.

--- a/demo/Part-1_Gelato_Providers/step2-assign-executor.js
+++ b/demo/Part-1_Gelato_Providers/step2-assign-executor.js
@@ -43,15 +43,21 @@ describe("Gelato-Kyber Demo Part 1: Step 2 => Executor Assignment", function () 
     const assignedExecutor = await gelatoCore.executorByProvider(
       myProviderAddress
     );
-    const noExecutorAssigned =
-      assignedExecutor === constants.AddressZero ? true : false;
 
     // The single Transaction that completes Steps 2-5: gelatoCore.multiProvide()
-    if (noExecutorAssigned) {
+    if (
+      ethers.utils.getAddress(assignedExecutor) !==
+      ethers.utils.getAddress(gelatoDefaultExecutor)
+    ) {
       // Gelato requires Executors to be staked.
       expect(await gelatoCore.isExecutorMinStaked(gelatoDefaultExecutor)).to.be
         .true;
 
+      if (assignedExecutor !== constants.AddressZero) {
+        console.log(
+          `\n Re-assign executor:${assignedExecutor} to gelato default executor\n`
+        );
+      }
       // Now we can safely send the assignment transaction.
       let assignExecutorTx;
       try {
@@ -75,7 +81,7 @@ describe("Gelato-Kyber Demo Part 1: Step 2 => Executor Assignment", function () 
         process.exit(1);
       }
     } else {
-      console.log("\n Already assigned Executor ✅ \n");
+      console.log("\n Already assigned gelato default Executor ✅\n");
     }
 
     // Lastly we check that Steps 2-5 were completed successfully

--- a/demo/Part-1_Gelato_Providers/step3-provide-funds.js
+++ b/demo/Part-1_Gelato_Providers/step3-provide-funds.js
@@ -28,12 +28,20 @@ describe("Gelato-Kyber Demo Part 1: Step 3 => Provide Funds", function () {
     // We get our Provider Wallet from the Buidler Runtime Env
     myProviderWallet = await bre.getProviderWallet();
     myProviderAddress = await myProviderWallet.getAddress();
+    const providerBalance = await myProviderWallet.getBalance();
 
-    if ((await myProviderWallet.getBalance()) < fundsToProvide) {
-      console.log("\n ❌  Insufficient funds on your Provider Wallet \n");
+    if (providerBalance.lt(fundsToProvide)) {
+      console.log(
+        `\n ❌  Insufficient funds on your Provider Wallet: ${myProviderAddress} \n`
+      );
       console.log(
         "\n Funds needed: ",
         utils.formatEther(fundsToProvide).toString(),
+        " ETH"
+      );
+      console.log(
+        "\n Provider's current Balance: ",
+        utils.formatEther(providerBalance).toString(),
         " ETH"
       );
       process.exit(1);


### PR DESCRIPTION
Issues (mark as fixed):

- [X]  `npx buidler compile` fails if no INFURA_ID is present. Hence devs can only run it after they added `.env`
- [X] Step 2: Assign your Executor - Test fails if another executor was already assigned
- [X] Step 3: Provide Funds: Requires `lt` operator instead of `<`

Further considerations, will be done in separate PR:
- [ ]  too many private key warning in my opinion. Warning devs one time at the beginning should suffice. Also the .gitignore already has `.env` in it, so the extra warning is redundant.
- [ ] Decouple explainer text from walkthrough
- [ ] Start with user flow and then introduce the provider complexity afterwards, as a solution to the pre-payment problem, but only when developers already understand it. 